### PR TITLE
Issue #16: Add info about SQLite/Python minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ sudo chown root:root /etc/sudoers.d/photoframe
 ## Setup Program
 
 ### Install Dependencies
+This only supports Python 3.10+ (`UPDATE..RETURNING` is only supported in SQLite 3.35.0+).
+
 ```bash
+# Required for GUI
 sudo apt install python3-tk
-sudo apt install jq
 ```
 
 ### Misc:


### PR DESCRIPTION
Closes #16 

Attempted to fix in https://github.com/Matthewar/photo-display/commit/bd52328158cb60c8fa3396d79b53042819600010 but not necessary, just set minimum version in readme.

Removed `jq` from install dependencies, was only used in command line when developing.